### PR TITLE
Raise an error if the header is missing in a bar chart

### DIFF
--- a/lib/chart/barchart.ex
+++ b/lib/chart/barchart.ex
@@ -237,7 +237,14 @@ shown. You can force the range using `force_value_range/2`
 
   defp get_svg_bars(%BarChart{dataset: dataset} = plot) do
     cat_col_index = Dataset.column_index(dataset, plot.category_col)
-    val_col_indices = Enum.map(plot.value_cols, fn col -> Dataset.column_index(dataset, col) end)
+
+    val_col_indices =
+      Enum.map(plot.value_cols, fn col ->
+        case Dataset.column_index(dataset, col) do
+          nil -> raise "Missing header \"#{col}\""
+          index -> index
+        end
+      end)
 
     series_fill_colours = plot.series_fill_colours
     fills = Enum.map(plot.value_cols, fn column -> CategoryColourScale.colour_for_value(series_fill_colours, column) end)

--- a/test/contex_plot_test.exs
+++ b/test/contex_plot_test.exs
@@ -1,14 +1,14 @@
 defmodule ContexPlotTest do
   use ExUnit.Case
 
-  alias Contex.{Plot, Dataset, PointPlot}
+  alias Contex.{Plot, Dataset, PointPlot, BarChart}
   import SweetXml
 
   setup do
-    plot = 
+    plot =
       Dataset.new([{1, 2, 3, 4}, {4, 5, 6, 4}, {-3, -2, -1, 0}], ["aa", "bb", "cccc", "d"])
       |> PointPlot.new()
-    
+
     plot = Plot.new(150, 200, plot)
     %{plot: plot}
   end
@@ -166,6 +166,35 @@ defmodule ContexPlotTest do
       assert svg.y_axis_label == %{text: "Y Side", x: "-82.5", y: "20"}
       assert svg.y_axis_label == %{text: "Y Side", x: "-82.5", y: "20"}
       assert svg.legend_transform == "translate(50, 65)"
+    end
+
+    test "raises error when category missing" do
+      test_data =
+        Dataset.new([["aa", 2, 3, 4], ["bb", 5, 6, 4]], [
+          "Category",
+          "Series 1",
+          "Series 2",
+          "Other Series"
+        ])
+
+      plot_content =
+        BarChart.new(test_data)
+        |> BarChart.set_val_col_names(["Series 1", "Series 2", "Wrong Name"])
+
+      plot = Plot.new(500, 400, plot_content)
+
+      plot =
+        Plot.titles(plot, "The Title", "The Sub")
+        |> Plot.axis_labels("X Side", "Y Side")
+        |> Plot.plot_options(%{legend_setting: :legend_right})
+
+      assert_raise(
+        RuntimeError,
+        "Missing header \"Wrong Name\"",
+        fn ->
+          Plot.to_svg(plot)
+        end
+      )
     end
   end
 end


### PR DESCRIPTION
Without this change a hard to decipher `bad argument in arithmetic expression` is raised.

Here's an example stack trace:

```
** (exit) an exception was raised:
    ** (ArithmeticError) bad argument in arithmetic expression
        :erlang.+(nil, 0)
        (contex) lib/chart/barchart.ex:287: anonymous fn/3 in Contex.BarChart.prepare_bar_values/3
        (elixir) lib/enum.ex:1948: Enum."-reduce/3-lists^foldl/2-0-"/3
        (contex) lib/chart/barchart.ex:286: Contex.BarChart.prepare_bar_values/3
        (contex) lib/chart/barchart.ex:254: Contex.BarChart.get_svg_bar/5
        (elixir) lib/enum.ex:1336: Enum."-map/2-lists^map/1-0-"/2
        (contex) lib/chart/barchart.ex:204: Contex.BarChart.to_svg/2
        (contex) lib/chart/plot.ex:118: Contex.Plot.to_svg/1
```