### PR TITLE
Barchart: Render integer labels as strings

### DIFF
--- a/lib/chart/barchart.ex
+++ b/lib/chart/barchart.ex
@@ -259,7 +259,13 @@ shown. You can force the range using `force_value_range/2`
 
     cat_band = OrdinalScale.get_band(category_scale, cat_data)
     bar_values = prepare_bar_values(series_values, value_scale, plot.type)
-    labels = Enum.map(series_values, fn val -> Scale.get_formatted_tick(value_scale, val) end)
+
+    labels =
+      Enum.map(series_values, fn val ->
+        Scale.get_formatted_tick(value_scale, val)
+        |> to_string()
+      end)
+
     event_handlers = get_bar_event_handlers(plot, cat_data, series_values)
     opacities = get_bar_opacities(plot, cat_data)
 

--- a/lib/chart/barchart.ex
+++ b/lib/chart/barchart.ex
@@ -259,13 +259,7 @@ shown. You can force the range using `force_value_range/2`
 
     cat_band = OrdinalScale.get_band(category_scale, cat_data)
     bar_values = prepare_bar_values(series_values, value_scale, plot.type)
-
-    labels =
-      Enum.map(series_values, fn val ->
-        Scale.get_formatted_tick(value_scale, val)
-        |> to_string()
-      end)
-
+    labels = Enum.map(series_values, fn val -> Scale.get_formatted_tick(value_scale, val) end)
     event_handlers = get_bar_event_handlers(plot, cat_data, series_values)
     opacities = get_bar_opacities(plot, cat_data)
 

--- a/lib/chart/scale/continuous_linear_scale.ex
+++ b/lib/chart/scale/continuous_linear_scale.ex
@@ -230,7 +230,7 @@ defmodule Contex.ContinuousLinearScale do
     end
 
     defp format_tick_text(tick, _, custom_tick_formatter) when is_function(custom_tick_formatter), do: custom_tick_formatter.(tick)
-    defp format_tick_text(tick, _, _) when is_integer(tick), do: tick
+    defp format_tick_text(tick, _, _) when is_integer(tick), do: to_string(tick)
     defp format_tick_text(tick, display_decimals, _) when display_decimals > 0 do
       :erlang.float_to_binary(tick, [decimals: display_decimals])
     end

--- a/test/contex_plot_test.exs
+++ b/test/contex_plot_test.exs
@@ -196,5 +196,36 @@ defmodule ContexPlotTest do
         end
       )
     end
+
+    test "renders integer data as bar labels" do
+      test_data =
+        Dataset.new([["aa", 42, 8.222222222]], [
+          "Category",
+          "Series 1",
+          "Series 2"
+        ])
+
+      plot_content =
+        BarChart.new(test_data)
+        |> BarChart.set_val_col_names(["Series 1", "Series 2"])
+
+      plot = Plot.new(500, 400, plot_content)
+
+      assert {:safe, svg} =
+               Plot.titles(plot, "The Title", "The Sub")
+               |> Plot.to_svg()
+
+      results =
+        svg
+        |> IO.chardata_to_string()
+        |> xpath(~x"/svg",
+          barlabels: [
+            ~x".//text[@class='exc-barlabel-in']"l,
+            text: ~x"./text()"s
+          ]
+        )
+
+      assert results.barlabels == [%{text: "42"}, %{text: "8.2"}]
+    end
   end
 end


### PR DESCRIPTION
Previously a `42` was being interpreted as an ascii value "*" since it was being rendered to iodata.

Based on #3 