### PR TITLE
Link to the website in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ContEx
 
-ContEx is a simple server side charting package for elixir.
+ContEx is a simple server side charting package for elixir. See these demos on the live site: https://contex-charts.org/
 
 ![Example Charts](./samples/mashup.png "Example Charts")
 


### PR DESCRIPTION
Currently the website is quite hidden. I only found it through the hexdocs logo link. I think having the live site be more prominent would be helpful for people interested in contex.

Would be nice to add it as the website in github as well