### PR TITLE
Add default styling

### DIFF
--- a/lib/chart/plot.ex
+++ b/lib/chart/plot.ex
@@ -38,7 +38,8 @@ defmodule Contex.Plot do
     :width,
     :plot_content,
     :margins,
-    :plot_options
+    :plot_options,
+    default_style: true
   ]
 
   @type t() :: %__MODULE__{}
@@ -59,6 +60,12 @@ defmodule Contex.Plot do
   @legend_width 100
   @x_axis_margin 20
   @x_axis_tick_labels 70
+  @default_style """
+  <style type="text/css"><![CDATA[
+    text {fill: black}
+    line {stroke: black}
+  ]]></style>
+  """
 
   @doc """
   Creates a new plot with specified dataset and plot type. Other plot attributes can be set via a
@@ -208,6 +215,7 @@ defmodule Contex.Plot do
       ~s|<svg version="1.1" xmlns="http://www.w3.org/2000/svg\" |,
       ~s|xmlns:xlink="http://www.w3.org/1999/xlink" class="chart" |,
       ~s|viewBox="0 0 #{width} #{height}" role="img">|,
+      get_default_style(plot),
       get_titles_svg(plot, content_width),
       get_axis_labels_svg(plot, content_width, content_height),
       ~s|<g transform="translate(#{left},#{top})">|,
@@ -229,6 +237,10 @@ defmodule Contex.Plot do
     |> Plot.to_svg()
     |> elem(1)
     |> List.insert_at(0, ~s|<?xml version="1.0" encoding="utf-8"?>|)
+  end
+
+  defp get_default_style(%Plot{} = plot) do
+    if plot.default_style, do: @default_style, else: ""
   end
 
   defp get_svg_legend(plot_content, legend_left, legend_top, %{legend_setting: :legend_right}) do

--- a/lib/contex.ex
+++ b/lib/contex.ex
@@ -13,10 +13,11 @@ defmodule Contex do
   A minimal example might look like:
   ```
     data = [["Apples", 10], ["Bananas", 12], ["Pears", 2]]
-    dataset = Contex.Dataset.new(data)
-    plot_content = Contex.BarChart.new(dataset)
-    plot = Contex.Plot.new(600, 400, plot_content)
-    output = Contex.Plot.to_svg(plot)
+    output =
+      data
+      |> Contex.Dataset.new()
+      |> Contex.Plot.new(Contex.BarChart, 600, 400)
+      |> Contex.Plot.to_svg(plot)
   ```
 
   ## CSS Styling

--- a/lib/contex.ex
+++ b/lib/contex.ex
@@ -20,7 +20,12 @@ defmodule Contex do
   ```
 
   ## CSS Styling
-  Various CSS classes are used to style the output. Sample CSS is shown below
+  A minimal stylesheet is embedded in the SVG by default, for the purpose of making lines and text
+  visible if no stylesheet is supplied. It is expected that these styles will be overridden using
+  provided Contex-specific classes. The default style can also be removed by setting the
+  `:default_style` Plot attribute to `false`.
+
+  Sample CSS is shown below:
   ```css
   /* Styling for tick line */
   .exc-tick {

--- a/test/contex_plot_test.exs
+++ b/test/contex_plot_test.exs
@@ -292,6 +292,23 @@ defmodule ContexPlotTest do
       assert svg.legend_transform == "translate(50, 65)"
     end
 
+    test "includes default styles by default", %{plot: plot} do
+      assert plot
+             |> Plot.to_svg()
+             |> elem(1)
+             |> IO.chardata_to_string()
+             |> String.contains?(~s|<style type="text/css">|)
+    end
+
+    test "does not render styles if default turned off", %{plot: plot} do
+      refute plot
+             |> struct(default_style: false)
+             |> Plot.to_svg()
+             |> elem(1)
+             |> IO.chardata_to_string()
+             |> String.contains?(~s|<style type="text/css">|)
+    end
+
     test "renders integer data as bar labels" do
       test_data =
         Dataset.new([["aa", 42, 8.222222222]], [


### PR DESCRIPTION
Closes #27. Second commit updates the basic example in the docs to reflect the pipe-friendly API. Just something I noticed on the way; no worries if you want to discard that one.