### PR TITLE
Added scale overrides to PointPlot and BarChart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Provide minimal default style so labels don't disappear unexpectedly if no CSS is set. Thanks @srowley.
 - XML declaration added to generated SVG so the output can be served as an image. Thanks @srowley.
 - Custom tick formatting enabled for PointPlot
+- Added `:custom_value_scale` to `BarChart` to allow overriding of the automatically generated scale
+- Added `:custom_x_scale` and `:custom_y_scale` to `PointPlot` to allow overriding of the automatically generated scales
 
 ### Deprecated
 - Most of the options set via functions, e.g. `BarChart.colours/2`. Use the options in the relevant `new` functions instead.

--- a/README.md
+++ b/README.md
@@ -68,13 +68,15 @@ Others under consideration:
 There are quite a few things to tidy up to make this ready for the real world, and the API is likely to be unstable for a little while yet...
 
 - [x] Reasonable docs - the best resource currently is the accompanying [demo project](https://github.com/mindok/contex-samples)
-- [ ] Default styling
+- [x] Default styling
 - [ ] Upgrade Elixir required version to 1.10 and fix up some of the data comparison operators to use the new sort capabilities. Holding off on this for a while so we don't force an unwanted Elixir upgrade.
 - [x] Multiple series in point plot
 - [ ] Line plot (probably option in point plot)
 - [x] Some test coverage - it has been built interactively using a liveview page for testing / refinement. Thanks to @srowley for getting some test coverage in place.
 - [ ] More test coverage... An approach for comparing "blessed" output SVG would make sense, including handling minor difference in spacing or element attribute order.
 - [ ] Options handling - needs to be better structured and use keyword lists rather than maps
+  - [x] Options for BarChart, PointPlot and GanttChart
+  - [ ] Plot options
 - [ ] Colour handling
 - [ ] Plot overlays (e.g. line chart on bar chart)
 - [x] SVG generation is poorly structured - lots of string interpolation. 

--- a/lib/chart/scale/continuous_linear_scale.ex
+++ b/lib/chart/scale/continuous_linear_scale.ex
@@ -133,7 +133,7 @@ defmodule Contex.ContinuousLinearScale do
               interval_count > 1 do
     width = max_d - min_d
     width = if width == 0.0, do: 1.0, else: width
-    unrounded_interval_size = width / (interval_count - 1)
+    unrounded_interval_size = width / interval_count
     order_of_magnitude = :math.ceil(:math.log10(unrounded_interval_size) - 1)
     power_of_ten = :math.pow(10, order_of_magnitude)
 

--- a/test/contex_axis_test.exs
+++ b/test/contex_axis_test.exs
@@ -4,6 +4,10 @@ defmodule ContexAxisTest do
   alias Contex.{Axis, ContinuousLinearScale}
   import SweetXml
 
+  # TODO: This is a bit brittle - most of the axis calculations are in float which is imprecise
+  # String representations in the output may not line up depending on how the floats
+  # are calculated on the day
+
   defp axis_map(axis) do
     Axis.to_svg(axis)
     |> IO.chardata_to_string()
@@ -121,7 +125,19 @@ defmodule ContexAxisTest do
     end
 
     test "positions tick marks properly", %{axis_map: axis_map} do
-      assert ["(0, 0.5)", "(0, 0.7)", "(0, 0.9)", "(0, 1.1)", "(0, 1.3)", "(0, 1.5)"] ==
+      assert [
+               "(0, 0.5)",
+               "(0, 0.6)",
+               "(0, 0.7)",
+               "(0, 0.8)",
+               "(0, 0.9)",
+               "(0, 1.0)",
+               "(0, 1.1)",
+               "(0, 1.2000000000000002)",
+               "(0, 1.3)",
+               "(0, 1.4)",
+               "(0, 1.5)"
+             ] ==
                Enum.map(axis_map.ticks, fn tick -> Map.get(tick, :transform) end)
                |> Enum.map(fn tick -> String.trim_leading(tick, "translate") end)
 
@@ -133,7 +149,19 @@ defmodule ContexAxisTest do
                Enum.map(axis_map.ticks, fn tick -> get_in(tick, [:text, :dy]) end)
                |> Enum.uniq()
 
-      assert ["0.00", "0.20", "0.40", "0.60", "0.80", "1.00"] ==
+      assert [
+               "0.000",
+               "0.100",
+               "0.200",
+               "0.300",
+               "0.400",
+               "0.500",
+               "0.600",
+               "0.700",
+               "0.800",
+               "0.900",
+               "1.000"
+             ] ==
                Enum.map(axis_map.ticks, fn tick -> get_in(tick, [:text, :text]) end)
     end
   end
@@ -161,7 +189,19 @@ defmodule ContexAxisTest do
     end
 
     test "positions tick marks properly", %{axis_map: axis_map} do
-      assert ["(0.5,0)", "(0.7,0)", "(0.9,0)", "(1.1,0)", "(1.3,0)", "(1.5,0)"] ==
+      assert [
+               "(0.5,0)",
+               "(0.6,0)",
+               "(0.7,0)",
+               "(0.8,0)",
+               "(0.9,0)",
+               "(1.0,0)",
+               "(1.1,0)",
+               "(1.2000000000000002,0)",
+               "(1.3,0)",
+               "(1.4,0)",
+               "(1.5,0)"
+             ] ==
                Enum.map(axis_map.ticks, fn tick -> Map.get(tick, :transform) end)
                |> Enum.map(fn tick -> String.trim_leading(tick, "translate") end)
 
@@ -173,7 +213,19 @@ defmodule ContexAxisTest do
                Enum.map(axis_map.ticks, fn tick -> get_in(tick, [:text, :dy]) end)
                |> Enum.uniq()
 
-      assert ["0.00", "0.20", "0.40", "0.60", "0.80", "1.00"] ==
+      assert [
+               "0.000",
+               "0.100",
+               "0.200",
+               "0.300",
+               "0.400",
+               "0.500",
+               "0.600",
+               "0.700",
+               "0.800",
+               "0.900",
+               "1.000"
+             ] ==
                Enum.map(axis_map.ticks, fn tick -> get_in(tick, [:text, :text]) end)
     end
   end
@@ -203,7 +255,19 @@ defmodule ContexAxisTest do
     # TODO
     # For top/bottom there's not space between the values;
     test "positions tick marks properly", %{axis_map: axis_map} do
-      assert ["(0.5,0)", "(0.7,0)", "(0.9,0)", "(1.1,0)", "(1.3,0)", "(1.5,0)"] ==
+      assert [
+               "(0.5,0)",
+               "(0.6,0)",
+               "(0.7,0)",
+               "(0.8,0)",
+               "(0.9,0)",
+               "(1.0,0)",
+               "(1.1,0)",
+               "(1.2000000000000002,0)",
+               "(1.3,0)",
+               "(1.4,0)",
+               "(1.5,0)"
+             ] ==
                Enum.map(axis_map.ticks, fn tick -> Map.get(tick, :transform) end)
                |> Enum.map(fn tick -> String.trim_leading(tick, "translate") end)
 
@@ -215,7 +279,19 @@ defmodule ContexAxisTest do
                Enum.map(axis_map.ticks, fn tick -> get_in(tick, [:text, :dy]) end)
                |> Enum.uniq()
 
-      assert ["0.00", "0.20", "0.40", "0.60", "0.80", "1.00"] ==
+      assert [
+               "0.000",
+               "0.100",
+               "0.200",
+               "0.300",
+               "0.400",
+               "0.500",
+               "0.600",
+               "0.700",
+               "0.800",
+               "0.900",
+               "1.000"
+             ] ==
                Enum.map(axis_map.ticks, fn tick -> get_in(tick, [:text, :text]) end)
     end
   end
@@ -243,7 +319,19 @@ defmodule ContexAxisTest do
     end
 
     test "positions tick marks properly", %{axis_map: axis_map} do
-      assert ["(0, 0.5)", "(0, 0.7)", "(0, 0.9)", "(0, 1.1)", "(0, 1.3)", "(0, 1.5)"] ==
+      assert [
+               "(0, 0.5)",
+               "(0, 0.6)",
+               "(0, 0.7)",
+               "(0, 0.8)",
+               "(0, 0.9)",
+               "(0, 1.0)",
+               "(0, 1.1)",
+               "(0, 1.2000000000000002)",
+               "(0, 1.3)",
+               "(0, 1.4)",
+               "(0, 1.5)"
+             ] ==
                Enum.map(axis_map.ticks, fn tick -> Map.get(tick, :transform) end)
                |> Enum.map(fn tick -> String.trim_leading(tick, "translate") end)
 
@@ -255,7 +343,19 @@ defmodule ContexAxisTest do
                Enum.map(axis_map.ticks, fn tick -> get_in(tick, [:text, :dy]) end)
                |> Enum.uniq()
 
-      assert ["0.00", "0.20", "0.40", "0.60", "0.80", "1.00"] ==
+      assert [
+               "0.000",
+               "0.100",
+               "0.200",
+               "0.300",
+               "0.400",
+               "0.500",
+               "0.600",
+               "0.700",
+               "0.800",
+               "0.900",
+               "1.000"
+             ] ==
                Enum.map(axis_map.ticks, fn tick -> get_in(tick, [:text, :text]) end)
     end
   end


### PR DESCRIPTION
Allow scales used for PointPlot and BarChart to be overridden in options
Fixes #33 