### PR TITLE
Fix invalid dates when current month has less than 31 days

### DIFF
--- a/lib/chart/scale/time_scale.ex
+++ b/lib/chart/scale/time_scale.ex
@@ -187,23 +187,15 @@ defmodule Contex.TimeScale do
   defp round_down_to(dt, {:days, 1, _}),
     do: %{dt | microsecond: {0, 0}, second: 0, minute: 0, hour: 0}
 
-  defp round_down_to(dt, {:days, n, _}) do
-    rounded_day =
-      round_down_multiple(dt.day, n)
-      |> case do
-        0 -> 1
-        day -> day
-      end
-
-    %{
+  defp round_down_to(dt, {:days, n, _}),
+    do: %{
       dt
       | microsecond: {0, 0},
         second: 0,
         minute: 0,
         hour: 0,
-        day: rounded_day
+        day: round_down_multiple(dt.day, n) |> max(1)
     }
-  end
 
   defp round_down_to(dt, {:months, 1, _}),
     do: %{dt | microsecond: {0, 0}, second: 0, minute: 0, hour: 0, day: 1}

--- a/lib/chart/scale/time_scale.ex
+++ b/lib/chart/scale/time_scale.ex
@@ -187,15 +187,23 @@ defmodule Contex.TimeScale do
   defp round_down_to(dt, {:days, 1, _}),
     do: %{dt | microsecond: {0, 0}, second: 0, minute: 0, hour: 0}
 
-  defp round_down_to(dt, {:days, n, _}),
-    do: %{
+  defp round_down_to(dt, {:days, n, _}) do
+    rounded_day =
+      round_down_multiple(dt.day, n)
+      |> case do
+        0 -> 1
+        day -> day
+      end
+
+    %{
       dt
       | microsecond: {0, 0},
         second: 0,
         minute: 0,
         hour: 0,
-        day: round_down_multiple(dt.day, n) + 1
+        day: rounded_day
     }
+  end
 
   defp round_down_to(dt, {:months, 1, _}),
     do: %{dt | microsecond: {0, 0}, second: 0, minute: 0, hour: 0, day: 1}

--- a/test/contex_timescale_test.exs
+++ b/test/contex_timescale_test.exs
@@ -97,6 +97,27 @@ defmodule ContexTimeScaleTest do
       assert expected_ticks == Scale.ticks_domain(scale)
     end
 
+    test "for 10 day timescale (end of month start)" do
+      scale =
+        create_timescale(
+          {~U[2015-11-30 13:00:00.056Z], ~U[2015-12-13 13:00:05.000Z]},
+          {0.0, 100.0}
+        )
+
+      expected_ticks = [
+        ~U[2015-11-30 00:00:00Z],
+        ~U[2015-12-02 00:00:00Z],
+        ~U[2015-12-04 00:00:00Z],
+        ~U[2015-12-06 00:00:00Z],
+        ~U[2015-12-08 00:00:00Z],
+        ~U[2015-12-10 00:00:00Z],
+        ~U[2015-12-12 00:00:00Z],
+        ~U[2015-12-14 00:00:00Z]
+      ]
+
+      assert expected_ticks == Scale.ticks_domain(scale)
+    end
+
     test "for 10 day timescale - 8 intervals" do
       scale =
         create_timescale(


### PR DESCRIPTION
Hey there,

while working on my graphs application I stumbled over a situation where my app crashed for a specific time scale.

The `min_d` got the following datetime `~U[2015-11-30 00:00:00Z]` from the `DataSet`.
In the round function it then tried to round down everything with 10 days tick to get the starting day.

```
div(30,10) * 10 # => 30
round_down_multiple(dt.day, n) + 1 # => 31
```
 
But the there is no valid date for the 2015-11-31 in the calendar which later in the code leads to an exception in the `Calendar` module. Probably the same would happen in the month of February.

This code tries to fix this under the assumption that the original code was only focussed on solving `day == 0` situation.

Hope you find this PR useful! 

