### PR TITLE
Fix ContinuousLinearScale lookup axis interval

### DIFF
--- a/lib/chart/scale/continuous_linear_scale.ex
+++ b/lib/chart/scale/continuous_linear_scale.ex
@@ -159,7 +159,7 @@ defmodule Contex.ContinuousLinearScale do
 
   @axis_interval_breaks [0.1, 0.2, 0.25, 0.4, 0.5, 1.0, 2.0, 2.5, 4.0, 5.0, 10.0]
   defp lookup_axis_interval(raw_interval) when is_float(raw_interval) do
-    Enum.find(@axis_interval_breaks, fn x -> x >= raw_interval end)
+    Enum.find(@axis_interval_breaks, 10.0, fn x -> x >= raw_interval end)
   end
 
   defp guess_display_decimals(power_of_ten) when power_of_ten > 0 do

--- a/test/contex_continuous_linear_scale_test.exs
+++ b/test/contex_continuous_linear_scale_test.exs
@@ -1,0 +1,33 @@
+defmodule ContinuousLinearScaleTest do
+  use ExUnit.Case
+
+  alias Contex.ContinuousLinearScale
+
+  describe "new/0" do
+    test "returns a ContinuousLinearScale struct with default values" do
+      scale = ContinuousLinearScale.new()
+
+      assert scale.range == {0.0, 1.0}
+      assert scale.interval_count == 10
+      assert scale.display_decimals == nil
+    end
+  end
+
+  describe "domain/2" do
+    test "returns a ContinuousLinearScale" do
+      scale =
+        ContinuousLinearScale.new()
+        |> ContinuousLinearScale.domain([1.2, 2.4, 0.5, 0.2, 2.8])
+
+      assert scale.domain == {0.2, 2.8}
+    end
+
+    test "returns a ContinuousLinearScale for data with small values (largest_value <= 0.0001)" do
+      scale =
+        ContinuousLinearScale.new()
+        |> ContinuousLinearScale.domain([0.0, 0.0001, 0.0, 0.0001, 0.0])
+
+      assert scale.domain == {0.0, 0.0001}
+    end
+  end
+end


### PR DESCRIPTION
Hello

### Background
I'm using this project to draw a Sparkline chart and I got the error `(ArithmeticError) bad argument in arithmetic expression`.
While debugging it I've realized that it's driven from ContinuousLinearScale's lookup_axis_interval function.

When the domain max value is `0.0001` or less, the calculations that are done at `nice/1` - https://github.com/mindok/contex/blob/master/lib/chart/scale/continuous_linear_scale.ex#L129 - pass an amount slightly larger than `10` to `lookup_axis_interval/1`.

Then this turns into a snowball... `lookup_axis_interval/1` returns nil because nothing matches the condition and finally the error happens due to an attempt of multiplying `nil` with some value - https://github.com/mindok/contex/blob/master/lib/chart/scale/continuous_linear_scale.ex#L141

### The fix
Returning a default value on `lookup_axis_interval/1` seemed to be the best solution (10.0 because it's the largest value of `@axis_interval_breaks`).
I rerun the Sparkline chart I was trying to draw and it works properly with the data `[0.0, 0.0001, 0.0, 0.0001, 0.0]`


![Screenshot 2021-09-20 at 10 32 24](https://user-images.githubusercontent.com/18558899/133986425-4cc9df20-1ac4-4dfb-9422-54497cf912d2.png)
_Sparkline chart after the fix_

