### PR TITLE
Adding plot options to PointPlot and LinePlot

### DIFF
--- a/lib/chart/lineplot.ex
+++ b/lib/chart/lineplot.ex
@@ -179,17 +179,29 @@ defmodule Contex.LinePlot do
   def get_svg_legend(_), do: ""
 
   @doc false
-  def to_svg(%LinePlot{} = plot) do
+  def to_svg(%LinePlot{} = plot, plot_options) do
     plot = prepare_scales(plot)
     x_scale = plot.x_scale
     y_scale = plot.y_scale
 
-    axis_x = get_x_axis(x_scale, plot)
-    axis_y = Axis.new_left_axis(y_scale) |> Axis.set_offset(get_option(plot, :width))
+    x_axis_svg =
+      if plot_options.show_x_axis,
+        do:
+          get_x_axis(x_scale, plot)
+          |> Axis.to_svg(),
+        else: ""
+
+    axis_y_svg =
+      if plot_options.show_y_axis,
+        do:
+          Axis.new_left_axis(y_scale)
+          |> Axis.set_offset(get_option(plot, :width))
+          |> Axis.to_svg(),
+      else: ""
 
     [
-      Axis.to_svg(axis_x),
-      Axis.to_svg(axis_y),
+      x_axis_svg,
+      axis_y_svg,
       "<g>",
       get_svg_lines(plot),
       "</g>"

--- a/lib/chart/lineplot.ex
+++ b/lib/chart/lineplot.ex
@@ -56,6 +56,12 @@ defmodule Contex.LinePlot do
     colour_palette: :default
   ]
 
+  @default_plot_options %{
+    show_x_axis: true,
+    show_y_axis: true,
+    legend_setting: :legend_none
+  }
+
   @type t() :: %__MODULE__{}
 
   @doc ~S"""
@@ -184,6 +190,8 @@ defmodule Contex.LinePlot do
     x_scale = plot.x_scale
     y_scale = plot.y_scale
 
+    plot_options = Map.merge(@default_plot_options, plot_options)
+
     x_axis_svg =
       if plot_options.show_x_axis,
         do:
@@ -191,17 +199,17 @@ defmodule Contex.LinePlot do
           |> Axis.to_svg(),
         else: ""
 
-    axis_y_svg =
+    y_axis_svg =
       if plot_options.show_y_axis,
         do:
           Axis.new_left_axis(y_scale)
           |> Axis.set_offset(get_option(plot, :width))
           |> Axis.to_svg(),
-      else: ""
+        else: ""
 
     [
       x_axis_svg,
-      axis_y_svg,
+      y_axis_svg,
       "<g>",
       get_svg_lines(plot),
       "</g>"

--- a/lib/chart/plot.ex
+++ b/lib/chart/plot.ex
@@ -403,13 +403,13 @@ defimpl Contex.PlotContent, for: Contex.BarChart do
 end
 
 defimpl Contex.PlotContent, for: Contex.PointPlot do
-  def to_svg(plot, _options), do: Contex.PointPlot.to_svg(plot)
+  def to_svg(plot, options), do: Contex.PointPlot.to_svg(plot, options)
   def get_svg_legend(plot), do: Contex.PointPlot.get_svg_legend(plot)
   def set_size(plot, width, height), do: Contex.PointPlot.set_size(plot, width, height)
 end
 
 defimpl Contex.PlotContent, for: Contex.LinePlot do
-  def to_svg(plot, _options), do: Contex.LinePlot.to_svg(plot)
+  def to_svg(plot, options), do: Contex.LinePlot.to_svg(plot, options)
   def get_svg_legend(plot), do: Contex.LinePlot.get_svg_legend(plot)
   def set_size(plot, width, height), do: Contex.LinePlot.set_size(plot, width, height)
 end

--- a/lib/chart/pointplot.ex
+++ b/lib/chart/pointplot.ex
@@ -304,17 +304,29 @@ defmodule Contex.PointPlot do
   def get_svg_legend(_), do: ""
 
   @doc false
-  def to_svg(%PointPlot{} = plot) do
+  def to_svg(%PointPlot{} = plot, plot_options) do
     plot = prepare_scales(plot)
     x_scale = plot.x_scale
     y_scale = plot.y_scale
 
-    axis_x = get_x_axis(x_scale, plot)
-    axis_y = Axis.new_left_axis(y_scale) |> Axis.set_offset(get_option(plot, :width))
+    x_axis_svg =
+      if plot_options.show_x_axis,
+        do:
+          get_x_axis(x_scale, plot)
+          |> Axis.to_svg(),
+        else: ""
+
+    axis_y_svg =
+      if plot_options.show_y_axis,
+        do:
+          Axis.new_left_axis(y_scale)
+          |> Axis.set_offset(get_option(plot, :width))
+          |> Axis.to_svg(),
+      else: ""
 
     [
-      Axis.to_svg(axis_x),
-      Axis.to_svg(axis_y),
+      x_axis_svg,
+      axis_y_svg,
       "<g>",
       get_svg_points(plot),
       "</g>"

--- a/lib/chart/pointplot.ex
+++ b/lib/chart/pointplot.ex
@@ -52,6 +52,12 @@ defmodule Contex.PointPlot do
     colour_palette: :default
   ]
 
+  @default_plot_options %{
+    show_x_axis: true,
+    show_y_axis: true,
+    legend_setting: :legend_none
+  }
+
   @type t() :: %__MODULE__{}
 
   @doc ~S"""
@@ -309,6 +315,8 @@ defmodule Contex.PointPlot do
     x_scale = plot.x_scale
     y_scale = plot.y_scale
 
+    plot_options = Map.merge(@default_plot_options, plot_options)
+
     x_axis_svg =
       if plot_options.show_x_axis,
         do:
@@ -316,17 +324,17 @@ defmodule Contex.PointPlot do
           |> Axis.to_svg(),
         else: ""
 
-    axis_y_svg =
+    y_axis_svg =
       if plot_options.show_y_axis,
         do:
           Axis.new_left_axis(y_scale)
           |> Axis.set_offset(get_option(plot, :width))
           |> Axis.to_svg(),
-      else: ""
+        else: ""
 
     [
       x_axis_svg,
-      axis_y_svg,
+      y_axis_svg,
       "<g>",
       get_svg_points(plot),
       "</g>"

--- a/test/contex_point_plot_test.exs
+++ b/test/contex_point_plot_test.exs
@@ -110,8 +110,10 @@ defmodule ContexPointPlotTest do
     # Axis svg not tested as it is for practical purposes handled
     # by Contex.Axis, which is tested by ContexAxisTest
     test "returns properly constructed chart", %{plot: plot} do
+      opts = %{show_x_axis: true, show_y_axis: true}
+
       points_map =
-        PointPlot.to_svg(plot)
+        PointPlot.to_svg(plot, opts)
         |> plot_iodata_to_map()
 
       assert ["fill:#1f77b4;"] ==
@@ -136,15 +138,22 @@ defmodule ContexPointPlotTest do
           %{"aa" => 4, "bb" => 5, "cccc" => 6, "dd" => 4},
           %{"aa" => -3, "bb" => -2, "cccc" => -1, "dd" => 0}
         ])
-        |> PointPlot.new(mapping: %{x_col: "aa", y_cols: ["bb"]})
+        |> Plot.new(PointPlot, 200, 200, mapping: %{x_col: "aa", y_cols: ["bb"]})
+        |> Plot.to_svg()
 
-      assert PointPlot.to_svg(plot) == PointPlot.to_svg(other_plot)
+      assert other_plot ==
+               plot.dataset
+               |> Plot.new(PointPlot, 200, 200)
+               |> Plot.to_svg()
     end
 
     test "renders custom fill colors properly", %{plot: plot} do
+      plot = PointPlot.set_colour_col_name(plot, "d")
+
       points_map =
-        PointPlot.set_colour_col_name(plot, "d")
-        |> PointPlot.to_svg()
+        Plot.new(200, 200, plot)
+        |> Plot.to_svg()
+        |> elem(1)
         |> plot_iodata_to_map()
 
       assert 2 ==


### PR DESCRIPTION
Adding support for the plot options, allowing PointPlot and LinePlot to show/hide the x/y axis.

I've added default plot options as requested. Note the `@default_plot_options` are a copy of the original from the `plot.ex` file, except it's now a map instead of a keyword list (if i understand correctly, that's the goal and it's converted by `Plot.parse_attributes/1` before the being sent to the underlying implementation).

Let me know if that's good 😉

Closes #56 