### PR TITLE
Docs: Fix incorrect variable reference

### DIFF
--- a/lib/contex.ex
+++ b/lib/contex.ex
@@ -17,7 +17,7 @@ defmodule Contex do
       data
       |> Contex.Dataset.new()
       |> Contex.Plot.new(Contex.BarChart, 600, 400)
-      |> Contex.Plot.to_svg(plot)
+      |> Contex.Plot.to_svg()
   ```
 
   ## CSS Styling


### PR DESCRIPTION
There was a variable referenced that wasn't defined and was unnecessary. The snippet now runs and produces output.