### PR TITLE
Fix running the tests on later versions of elixir

### DIFF
--- a/test/contex_line_chart_test.exs
+++ b/test/contex_line_chart_test.exs
@@ -1,8 +1,7 @@
-defmodule ContexPointPlotTest do
+defmodule ContexLineChartTest do
   use ExUnit.Case
 
-  alias Contex.{CategoryColourScale, Dataset, LinePlot, Plot}
-  import SweetXml
+  alias Contex.{Dataset, LinePlot}
 
   setup do
     plot =
@@ -28,7 +27,7 @@ defmodule ContexPointPlotTest do
         {404, 20}
       ]
 
-      expected_output = """
+      _expected_output = """
       d=M20,380
       C26.333333333333332,373.6666666666667 44.666666666666664,348.3333333333333 58,342
       C71.33333333333333,335.6666666666667 93,349 100,342

--- a/test/contex_linear_scale_test.exs
+++ b/test/contex_linear_scale_test.exs
@@ -1,4 +1,4 @@
-defmodule ContexAxisTest do
+defmodule ContexLinearScaleTest do
   use ExUnit.Case
 
   alias Contex.ContinuousLinearScale


### PR DESCRIPTION
At some point it seems that ex_unit stopped running tests where there are multiple modules with the same name. In this case it appears that the duplicate names were a copy-paste issue so I've fixed the names.

Here's the test failure I get before this fix:
> == Compilation error in file test/contex_point_plot_test.exs ==
> ** (CompileError) test/contex_point_plot_test.exs:1: cannot define module ContexPointPlotTest because it is currently being defined in test/contex_line_chart_test.exs:1
>     (elixir 1.13.4) lib/kernel/parallel_compiler.ex:455: Kernel.ParallelCompiler.require_file/2
>     (elixir 1.13.4) lib/kernel/parallel_compiler.ex:348: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/7

I've also fixed a few compilation warnings.

But it looks like the ContexLineChartTest needs to be finished or adjusted since it's not really testing anything right now (except that an error is not raised).