### PR TITLE
Fix Plot default_style issue

### DIFF
--- a/lib/chart/axis.ex
+++ b/lib/chart/axis.ex
@@ -113,7 +113,7 @@ defmodule Contex.Axis do
     [
       "<g ",
       get_svg_axis_location(axis),
-      ~s| fill="none" font-size="10" text-anchor="#{get_text_anchor(axis)}">|,
+      ~s| fill="none" text-anchor="#{get_text_anchor(axis)}">|,
       ~s|<path class="exc-domain" stroke="#000" d="#{get_svg_axis_line(axis, range0, range1)}"></path>|,
       get_svg_tickmarks(axis),
       "</g>"

--- a/lib/chart/plot.ex
+++ b/lib/chart/plot.ex
@@ -151,12 +151,11 @@ defmodule Contex.Plot do
     plot_options =
       Map.merge(
         plot.plot_options,
-        Map.take(attributes_map, [:show_x_axis, :show_y_axis, :legend_setting])
+        Map.take(attributes_map, [:show_x_axis, :show_y_axis, :legend_setting, :default_style])
       )
-
     plot
     |> Map.merge(
-      Map.take(attributes_map, [:title, :subtitle, :x_label, :y_label, :width, :height])
+      Map.take(attributes_map, [:title, :subtitle, :x_label, :y_label, :width, :height, :default_style])
     )
     |> Map.put(:plot_options, plot_options)
     |> calculate_margins()
@@ -336,6 +335,7 @@ defmodule Contex.Plot do
       subtitle: Keyword.get(attrs, :subtitle),
       x_label: Keyword.get(attrs, :x_label),
       y_label: Keyword.get(attrs, :y_label),
+      default_style: Keyword.get(attrs, :default_style),
       plot_options:
         Enum.into(Keyword.take(attrs, [:show_x_axis, :show_y_axis, :legend_setting]), %{})
     }

--- a/test/contex_plot_test.exs
+++ b/test/contex_plot_test.exs
@@ -306,7 +306,7 @@ defmodule ContexPlotTest do
 
     test "does not render styles if default turned off", %{plot: plot} do
       refute plot
-             |> struct(default_style: false)
+             |> Plot.attributes(default_style: false)
              |> Plot.to_svg()
              |> elem(1)
              |> IO.chardata_to_string()


### PR DESCRIPTION
default_style attribute can now be configured using Plot.attributes/2 function and Plot.new/x functions.