### PR TITLE
Fix test error in contex legend

### DIFF
--- a/test/contex_legend_test.exs
+++ b/test/contex_legend_test.exs
@@ -38,7 +38,7 @@ defmodule ContexLegendTest do
 
       # The other attributes are not tested because they are hard-coded.
       assert %{y: "0", style: "fill:#1f77b4;"} = legend.box
-      assert %{y: "9", text: "bb"} = legend.text
+      assert %{y: "9.0", text: "bb"} = legend.text
     end
   end
 end


### PR DESCRIPTION
```sh
$ mix test
...
  1) test to_svg/2 returns properly formatted legend (ContexLegendTest)
     test/contex_legend_test.exs:8
     match (=) failed
     code:  assert %{y: "9", text: "bb"} = legend.text
     left:  %{text: "bb", y: "9"}
     right: %{text: "bb", y: "9.0", dominant_baseline: "central", text_anchor: "start", x: "23"}
     stacktrace:
       test/contex_legend_test.exs:41: (test)
```