### PR TITLE
feat: allow LinePlot to be drawn in steps

### DIFF
--- a/lib/chart/lineplot.ex
+++ b/lib/chart/lineplot.ex
@@ -51,7 +51,7 @@ defmodule Contex.LinePlot do
     custom_y_formatter: nil,
     width: 100,
     height: 100,
-    smoothed: true,
+    plot_style: :smooth,
     stroke_width: "2",
     colour_palette: :default
   ]
@@ -106,7 +106,7 @@ defmodule Contex.LinePlot do
 
     - `:stroke_width` : 2 (default) - stroke width of the line
 
-    - `:smoothed` : true (default) or false - draw the lines smoothed
+    - `:plot_style` : :direct (default), :smooth or :step
 
   Note that the smoothing algorithm is a cardinal spline with tension = 0.3.
   You may get strange effects (e.g. loops / backtracks) in certain circumstances, e.g.
@@ -254,7 +254,7 @@ defmodule Contex.LinePlot do
          y_accessor,
          colour
        ) do
-    smooth = get_option(plot, :smoothed)
+    style = get_option(plot, :plot_style)
     stroke_width = get_option(plot, :stroke_width)
 
     options = [
@@ -282,7 +282,7 @@ defmodule Contex.LinePlot do
       |> Enum.chunk_by(fn {_x, y} -> is_nil(y) end)
       |> Enum.filter(fn [{_x, y} | _] -> not is_nil(y) end)
 
-    Enum.map(points_list, fn points -> line(points, smooth, options) end)
+    Enum.map(points_list, fn points -> line(points, style, options) end)
   end
 
   @doc false

--- a/lib/chart/lineplot.ex
+++ b/lib/chart/lineplot.ex
@@ -51,7 +51,6 @@ defmodule Contex.LinePlot do
     custom_y_formatter: nil,
     width: 100,
     height: 100,
-    plot_style: :smooth,
     stroke_width: "2",
     colour_palette: :default
   ]
@@ -107,6 +106,8 @@ defmodule Contex.LinePlot do
     - `:stroke_width` : 2 (default) - stroke width of the line
 
     - `:plot_style` : :direct (default), :smooth or :step
+
+  For backwards compatibility, the option :smoothed was kept and is translated: true -> :smooth and false -> :direct.
 
   Note that the smoothing algorithm is a cardinal spline with tension = 0.3.
   You may get strange effects (e.g. loops / backtracks) in certain circumstances, e.g.
@@ -254,7 +255,10 @@ defmodule Contex.LinePlot do
          y_accessor,
          colour
        ) do
-    style = get_option(plot, :plot_style)
+    # keep backwards compatibility with old `:smoothed` option
+    style = get_option(plot, :plot_style) |> IO.inspect(label: "style")
+    smoothed = get_option(plot, :smoothed) |> IO.inspect(label: "smoothed")
+    plot_style = if smoothed != nil, do: smoothed, else: style
     stroke_width = get_option(plot, :stroke_width)
 
     options = [
@@ -282,7 +286,7 @@ defmodule Contex.LinePlot do
       |> Enum.chunk_by(fn {_x, y} -> is_nil(y) end)
       |> Enum.filter(fn [{_x, y} | _] -> not is_nil(y) end)
 
-    Enum.map(points_list, fn points -> line(points, style, options) end)
+    Enum.map(points_list, fn points -> line(points, plot_style, options) end)
   end
 
   @doc false

--- a/lib/chart/svg.ex
+++ b/lib/chart/svg.ex
@@ -85,7 +85,7 @@ defmodule Contex.SVG do
 
   defp path([], _), do: ""
 
-  defp path(points, false) do
+  defp path(points, :direct) do
     Enum.reduce(points, :first, fn {x, y}, acc ->
       coord = ~s|#{x} #{y}|
 
@@ -94,9 +94,28 @@ defmodule Contex.SVG do
         _ -> [acc, [" L ", coord]]
       end
     end)
+    |> IO.inspect()
   end
 
-  defp path(points, true) do
+  defp path(points, :step) do
+    Enum.reduce(points, :first, fn {x, y}, acc ->
+      coord = ~s|#{x} #{y}|
+
+      case acc do
+        :first ->
+          ["M ", coord]
+
+        _ ->
+          previous_coord = acc |> List.last()
+          previous_y = previous_coord |> String.split(" ") |> List.last()
+          new_x = x
+          acc ++ [" L ", ~s|#{new_x} #{previous_y}|, " L ", coord]
+      end
+    end)
+    |> IO.inspect()
+  end
+
+  defp path(points, :smooth) do
     # Use Catmull-Rom curve - see http://schepers.cc/getting-to-the-point
     # First point stays as-is. Subsequent points are draw using SVG cubic-spline
     # where control points are calculated as follows:

--- a/lib/chart/svg.ex
+++ b/lib/chart/svg.ex
@@ -85,6 +85,10 @@ defmodule Contex.SVG do
 
   defp path([], _), do: ""
 
+  defp path(points, nil), do: path(points, :smooth)
+  defp path(points, true), do: path(points, IO.inspect(:smooth))
+  defp path(points, false), do: path(points, IO.inspect(:direct))
+
   defp path(points, :direct) do
     Enum.reduce(points, :first, fn {x, y}, acc ->
       coord = ~s|#{x} #{y}|

--- a/lib/chart/svg.ex
+++ b/lib/chart/svg.ex
@@ -69,10 +69,10 @@ defmodule Contex.SVG do
     ]
   end
 
-  def line(points, smoothed, opts \\ []) do
+  def line(points, plot_style, opts \\ []) do
     attrs = opts_to_attrs(opts)
 
-    path = path(points, smoothed)
+    path = path(points, plot_style)
 
     [
       "<path d=\"",

--- a/test/contex_line_chart_test.exs
+++ b/test/contex_line_chart_test.exs
@@ -41,7 +41,7 @@ defmodule ContexLineChartTest do
       C330.6666666666667,237.5 388.3333333333333,60 404,20 "
       """
 
-      output = Contex.SVG.line(points, true) |> IO.iodata_to_binary()
+      output = Contex.SVG.line(points, :smooth) |> IO.iodata_to_binary()
       IO.inspect(output)
     end
   end

--- a/test/contex_line_chart_test.exs
+++ b/test/contex_line_chart_test.exs
@@ -41,8 +41,12 @@ defmodule ContexLineChartTest do
       C330.6666666666667,237.5 388.3333333333333,60 404,20 "
       """
 
-      output = Contex.SVG.line(points, :smooth) |> IO.iodata_to_binary()
-      IO.inspect(output)
+      output_new = Contex.SVG.line(points, :smooth) |> IO.iodata_to_binary()
+      output_old = Contex.SVG.line(points, true) |> IO.iodata_to_binary()
+
+      assert output_new == output_old
+
+      IO.inspect(output_new)
     end
   end
 end


### PR DESCRIPTION
## Changes

Many timeseries depict a "state" of some sort that was measured at specific points in time.

Simply drawing a line between the points of measurement often feels weird to me. I rather think "the value has been y from t1 to t2, then at t2 we got a new value".

So I added a style for line graphs that creates a LinePlot with steps:

![image](https://github.com/user-attachments/assets/9330a569-4090-4288-b88a-5c6a0cc06208)

As we no longer have two options (smooth yes/no) but three options,
the interface needed to be changed:

The option is now called `plot_type`, with the options
- `:direct` 
- `:smooth`
- `:step`

If `plot_type` is not provided, we fall back to the `smoothed` option.