### PR TITLE
Addding an option for data labels displaying conditional

### DIFF
--- a/lib/chart/barchart.ex
+++ b/lib/chart/barchart.ex
@@ -59,6 +59,7 @@ defmodule Contex.BarChart do
     height: 100,
     padding: 2,
     data_labels: true,
+    max_number_of_cols_data_labels: 4,
     colour_palette: :default,
     phx_event_handler: nil,
     phx_event_target: nil,
@@ -544,7 +545,8 @@ defmodule Contex.BarChart do
       end)
 
     texts =
-      case count < 4 and get_option(plot, :data_labels) do
+      case count < get_option(plot, :max_number_of_cols_data_labels) and
+             get_option(plot, :data_labels) do
         false ->
           []
 

--- a/test/contex_bar_chart_test.exs
+++ b/test/contex_bar_chart_test.exs
@@ -87,6 +87,10 @@ defmodule ContexBarChartTest do
       plot = BarChart.data_labels(plot, false)
       assert get_option(plot, :data_labels) == false
     end
+
+    test "default max_number_of_cols_data_labels value should be 4", %{plot: plot} do
+      assert get_option(plot, :max_number_of_cols_data_labels) == 4
+    end
   end
 
   describe "type/2" do


### PR DESCRIPTION
# Summary
Adding an option to control the display of data_labels in case the number of columns are more than 4